### PR TITLE
Update PocketMine-MP.phar download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please copy all the downloaded files `cacert.pem`, `resolv.conf`, and `php.ini` 
  
 ## Install PocketMine-MP
 Please download "PocketMine-MP.phar" from the following link and copy it to "/storage/emulated/0/PocketMine/".
-https://jenkins.pmmp.io/job/PocketMine-MP/lastSuccessfulBuild/artifact/PocketMine-MP.phar
+https://github.com/pmmp/PocketMine-MP/releases/latest/download/PocketMine-MP.phar
 
 ## launch PocketMine-MP
 Launch "Android Terminal Emulator" downloaded from Google Play, and execute the following command.

--- a/README_JP.md
+++ b/README_JP.md
@@ -42,7 +42,7 @@ chmod 777 /data/data/jackpal.androidterm/app_HOME/php
  `/storage/emulated/0/PocketMine/config/`フォルダにコピーしましょう。 
  
 ## PocketMine-MPのインストール
-https://jenkins.pmmp.io/job/PocketMine-MP/lastSuccessfulBuild/artifact/PocketMine-MP.phar  
+https://github.com/pmmp/PocketMine-MP/releases/latest/download/PocketMine-MP.phar  
 ファイルをダウンロード致しまして、
 `/storage/emulated/0/PocketMine/`にコピーしましょう。
 


### PR DESCRIPTION
As you may have know, the distribution of PocketMine-MP.phar on Jenkins has been deprecated and disabled. Therefore, the PocketMine-MP.phar download link needs to be changed to GitHub Actions, which is currently active.